### PR TITLE
Update SF helper to round robin account records

### DIFF
--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -1,0 +1,33 @@
+name: Test changes
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Set the Node.js version
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+
+
+    # Download dependencies (including dev deps)
+    - run: npm install
+
+    # Run sanity checks
+    - run: npm test

--- a/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -155,35 +155,60 @@ module.exports = {
           });
         }
         // console.log(existingAccountRecord);
-        // If we found an exisitng account, we'll assign the new contact to the account owner.
-        if(existingAccountRecord) {
+        // If we found an exisitng account and it is not owned by the integrations admin, we'll use assign the new contact to the account owner.
+        if(existingAccountRecord && existingAccountRecord.OwnerId !== '0054x00000735wDAAQ') {
           // Store the ID of the Account record we found.
           salesforceAccountId = existingAccountRecord.Id;
           salesforceAccountOwnerId = existingAccountRecord.OwnerId;
           // console.log('exising account found!', salesforceAccountId);
         } else {
-          // If no existing account record was found, create a new one, and assign it to the "Integrations Admin" user.
-          salesforceAccountOwnerId = '0054x00000735wDAAQ';// « "Integrations admin" user.
-          // Create a timestamp to use for the new account's assigned date.
+          // If we didn't find an existing record, or found one onwned by the integrations admin or a disabled user, we'll round robin it between the AE's Salesforce users.
+          let roundRobinUsers = await salesforceConnection.sobject('User')
+          .find({
+            AE_Round_robin__c: true,// eslint-disable-line camelcase
+          });
+          let userWithEarliestAssignTimeStamp = _.sortBy(roundRobinUsers, 'AE_Account_Assignment_round_robin__c')[0];
+
           let today = new Date();
           let nowOn = today.toISOString().replace('Z', '+0000');
-
-          let newAccountRecord = await salesforceConnection.sobject('Account')
-          .create({
-            Account_Assigned_date__c: nowOn,// eslint-disable-line camelcase
+          // Update the accountOwnerId value to be the ID of the next user in the round robin.
+          salesforceAccountOwnerId = userWithEarliestAssignTimeStamp.Id;
+          // Update this user to put them at the bottom of the round robin list.
+          await salesforceConnection.sobject('User')
+          .update({
+            Id: salesforceAccountOwnerId,
             // eslint-disable-next-line camelcase
-            Current_Assignment_Reason__c: 'Inbound Lead',// TODO verify that this matters. if not, do not set it.
-            Prospect_Status__c: 'Assigned',// eslint-disable-line camelcase
-
-            Name: enrichmentData.employer.organization,// IFWMIH: We know organization exists
-            Website: enrichmentData.employer.emailDomain,
-            LinkedIn_company_URL__c: enrichmentData.employer.linkedinCompanyPageUrl,// eslint-disable-line camelcase
-            NumberOfEmployees: enrichmentData.employer.numberOfEmployees,
-            OwnerId: salesforceAccountOwnerId
+            AE_Account_Assignment_round_robin__c: nowOn
           });
-          salesforceAccountId = newAccountRecord.id;
+
+
+          if(existingAccountRecord){
+            // If we found an existing Account record owned by the integrations admin user account, reassign it to the new owner.
+            salesforceAccountId = existingAccountRecord.Id;
+            await salesforceConnection.sobject('Account')
+            .update({
+              Id: salesforceAccountId,
+              OwnerId: salesforceAccountOwnerId
+            });
+          } else {
+            // If no existing account record was found, create a new one.
+            let newAccountRecord = await salesforceConnection.sobject('Account')
+            .create({
+              OwnerId: salesforceAccountOwnerId,
+              Account_Assigned_date__c: nowOn,// eslint-disable-line camelcase
+              // eslint-disable-next-line camelcase
+              Current_Assignment_Reason__c: 'Inbound Lead',// TODO verify that this matters. if not, do not set it.
+              Prospect_Status__c: 'Assigned',// eslint-disable-line camelcase
+
+              Name: enrichmentData.employer.organization,// IFWMIH: We know organization exists
+              Website: enrichmentData.employer.emailDomain,
+              LinkedIn_company_URL__c: enrichmentData.employer.linkedinCompanyPageUrl,// eslint-disable-line camelcase
+              NumberOfEmployees: enrichmentData.employer.numberOfEmployees,
+            });
+            salesforceAccountId = newAccountRecord.id;
+          }//ﬁ
+          // console.log('New account created!', salesforceAccountId);
         }//ﬁ
-        // console.log('New account created!', salesforceAccountId);
       }//ﬁ
 
       // Only set leadSource on new contact records.


### PR DESCRIPTION
Changes:
- Updated the update-or-create-contact-and-account helper to round-robin accounts owned by the integrations admin when new contacts are created
